### PR TITLE
The callRestApi test method can now set headers as well

### DIFF
--- a/src/Test/Integration/FeatureContextAbstract.php
+++ b/src/Test/Integration/FeatureContextAbstract.php
@@ -151,7 +151,13 @@ abstract class FeatureContextAbstract implements Context
         return $result;
     }
 
-    protected function callRestApi(string $url, string $method = CurlHttpRequest::METHOD_GET, array $params = [], $storeResponse = true): CurlHttpRequestResult
+    protected function callRestApi(
+        string $url,
+        string $method = CurlHttpRequest::METHOD_GET,
+        array $params = [],
+        array $headers = [],
+        $storeResponse = true
+    ): CurlHttpRequestResult
     {
         $url = $url
             . (strpos($url, '?') === false ? '?' : '&')
@@ -163,6 +169,9 @@ abstract class FeatureContextAbstract implements Context
         $request->addHeader('Content-Type: application/json');
         if (!empty($this->sessionId)) {
             $request->addHeader('Authorization: Session ' . $this->sessionId);
+        }
+        foreach ($headers as $header) {
+            $request->addHeader($header);
         }
 
         $request->setPayload(json_encode($params), CurlHttpRequest::PAYLOAD_TYPE_RAW);


### PR DESCRIPTION
This is needed to be able to test the Storage API